### PR TITLE
feat(opencomputer): orchestrator support for the OpenComputer package

### DIFF
--- a/components/opencomputer/component.json
+++ b/components/opencomputer/component.json
@@ -1,0 +1,29 @@
+{
+  "name": "opencomputer",
+  "description": "OpenComputer (Mintplex Open Computer) — KVM agent-VM dashboard reverse-proxied via Traefik with basic-auth (single router, all paths).",
+  "dependencies": [],
+  "env": [
+    {
+      "name": "OC_SUBDOMAIN",
+      "required": true,
+      "default": "computer"
+    },
+    {
+      "name": "OC_DOMAIN",
+      "required": true
+    },
+    {
+      "name": "OC_AUTH_USER",
+      "required": true,
+      "default": "admin"
+    },
+    {
+      "name": "OC_AUTH_PASSWORD_HASH",
+      "required": true
+    },
+    {
+      "name": "EMAIL",
+      "required": false
+    }
+  ]
+}

--- a/components/opencomputer/compose.yaml
+++ b/components/opencomputer/compose.yaml
@@ -1,0 +1,18 @@
+  # Traefik reverse proxy for the OpenComputer agent dashboard.
+  # Routes {OC_SUBDOMAIN}.{OC_DOMAIN} → host 127.0.0.1:9800 (the interface-service,
+  # which serves the dashboard, agent chat, and the embedded noVNC desktop).
+  # The agent VM's QEMU forwards guest :8080 → host 127.0.0.1:9800 (loopback only).
+  # Host network mode lets Traefik reach the host's loopback interface.
+  # Single router with basic-auth on ALL paths: verified in Chromium + Firefox that
+  # the browser sends the cached basic-auth on the /ws/events and /desktop WebSocket
+  # upgrades, so no split router or Origin rewrite is needed (unlike Hermes).
+  traefik:
+    image: traefik:v3.6
+    restart: unless-stopped
+    network_mode: host
+    command:
+      - --configFile=/etc/traefik/traefik_config.yml
+    volumes:
+      - ./config/traefik:/etc/traefik:ro
+      - ./config/letsencrypt:/letsencrypt
+      - ./config/traefik/rules:/rules

--- a/components/opencomputer/config-setup.sh
+++ b/components/opencomputer/config-setup.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+set -e
+
+# OpenComputer Config Setup
+# Generates Traefik routing rules for the OpenComputer agent dashboard with basic-auth.
+
+log() { printf "%s\n" "$*"; }
+
+CONFIG_DIR="${MANIDAE_ROOT:-/host-setup}/config"
+TRAEFIK_DIR="${CONFIG_DIR}/traefik"
+RULES_DIR="${TRAEFIK_DIR}/rules"
+
+mkdir -p "${RULES_DIR}"
+
+# --- Traefik Main Config ---
+cat > "${TRAEFIK_DIR}/traefik_config.yml" <<EOF
+api:
+  dashboard: true
+  insecure: true
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+  websecure:
+    address: ":443"
+
+providers:
+  file:
+    directory: /rules
+    watch: true
+
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: "${EMAIL:-admin@${OC_DOMAIN}}"
+      storage: /letsencrypt/acme.json
+      httpChallenge:
+        entryPoint: web
+EOF
+
+# --- OpenComputer Routing Rule ---
+# ONE router, basic-auth on ALL paths → http://127.0.0.1:9800.
+# Validated (Chromium + Firefox): the browser sends the origin's cached basic-auth on
+# the /ws/events (agent event stream) and /desktop (noVNC) WebSocket handshakes, so a
+# single router suffices — no /api exemption, no Origin rewrite (the interface-service
+# has no WS Origin check and CORS is already '*').
+cat > "${RULES_DIR}/opencomputer.yml" <<EOF
+http:
+  middlewares:
+    opencomputer-auth:
+      basicAuth:
+        users:
+          - "${OC_AUTH_USER}:${OC_AUTH_PASSWORD_HASH}"
+
+  routers:
+    opencomputer:
+      rule: "Host(\`${OC_SUBDOMAIN}.${OC_DOMAIN}\`)"
+      service: opencomputer
+      entryPoints:
+        - websecure
+      middlewares:
+        - opencomputer-auth
+      tls:
+        certResolver: letsencrypt
+
+  services:
+    opencomputer:
+      loadBalancer:
+        servers:
+          - url: "http://127.0.0.1:9800"
+EOF
+
+log "✅ OpenComputer Traefik rules generated for ${OC_SUBDOMAIN}.${OC_DOMAIN}"

--- a/docker-compose-setup.yml
+++ b/docker-compose-setup.yml
@@ -90,6 +90,16 @@ services:
       - HERMES_DOMAIN=${HERMES_DOMAIN:-}
       - HERMES_AUTH_USER=${HERMES_AUTH_USER:-admin}
       - HERMES_AUTH_PASSWORD_HASH=${HERMES_AUTH_PASSWORD_HASH:-}
+      # OpenComputer platform variables
+      - OC_SUBDOMAIN=${OC_SUBDOMAIN:-computer}
+      - OC_DOMAIN=${OC_DOMAIN:-}
+      - OC_AUTH_USER=${OC_AUTH_USER:-admin}
+      - OC_AUTH_PASSWORD_HASH=${OC_AUTH_PASSWORD_HASH:-}
+      - OC_PROVIDER=${OC_PROVIDER:-}
+      - OC_MODEL=${OC_MODEL:-}
+      - OC_INFERENCE_API_KEY=${OC_INFERENCE_API_KEY:-}
+      - OC_INFERENCE_BASE_URL=${OC_INFERENCE_BASE_URL:-}
+      - OC_CONTEXT_WINDOW=${OC_CONTEXT_WINDOW:-}
       # OpenShell Controller subdomain (for Pangolin resource routing)
       - OPENSHELL_CONTROLLER_SUBDOMAIN=${OPENSHELL_CONTROLLER_SUBDOMAIN:-}
       # Integrations
@@ -147,6 +157,7 @@ services:
         NEMOCLAW_VARS_SET=false
         OPENCLAW_VARS_SET=false
         HERMES_VARS_SET=false
+        OPENCOMPUTER_VARS_SET=false
 
         if [ -n \"$$DOMAIN\" ] && [ -n \"$$EMAIL\" ]; then
           PANGOLIN_VARS_SET=true
@@ -173,7 +184,12 @@ services:
           HERMES_VARS_SET=true
         fi
 
-        if [ \"$$PANGOLIN_VARS_SET\" = false ] && [ \"$$COOLIFY_VARS_SET\" = false ] && [ \"$$NEMOCLAW_VARS_SET\" = false ] && [ \"$$OPENCLAW_VARS_SET\" = false ] && [ \"$$HERMES_VARS_SET\" = false ]; then
+        # For OpenComputer, check if COMPONENTS includes opencomputer OR OpenComputer env vars are set
+        if [ \"$$COMPONENTS\" = \"opencomputer\" ] || echo \"$$COMPONENTS\" | grep -q \"opencomputer\" || ([ -n \"$$OC_DOMAIN\" ] && [ -n \"$$OC_AUTH_PASSWORD_HASH\" ]); then
+          OPENCOMPUTER_VARS_SET=true
+        fi
+
+        if [ \"$$PANGOLIN_VARS_SET\" = false ] && [ \"$$COOLIFY_VARS_SET\" = false ] && [ \"$$NEMOCLAW_VARS_SET\" = false ] && [ \"$$OPENCLAW_VARS_SET\" = false ] && [ \"$$HERMES_VARS_SET\" = false ] && [ \"$$OPENCOMPUTER_VARS_SET\" = false ]; then
           echo '❌ Error: No platform detected!'
           echo ''
           echo '🐧 For Pangolin platform (required):'
@@ -260,6 +276,9 @@ services:
             elif [ -n \"$$HERMES_DOMAIN\" ] && [ -n \"$$HERMES_AUTH_PASSWORD_HASH\" ]; then
               echo \"[orchestrator] Detected Hermes Agent platform (HERMES_DOMAIN and HERMES_AUTH_PASSWORD_HASH are set)\"
               COMPONENTS=\"hermes-agent\"
+            elif [ -n \"$$OC_DOMAIN\" ] && [ -n \"$$OC_AUTH_PASSWORD_HASH\" ]; then
+              echo \"[orchestrator] Detected OpenComputer platform (OC_DOMAIN and OC_AUTH_PASSWORD_HASH are set)\"
+              COMPONENTS=\"opencomputer\"
             elif [ -n \"$$DOMAIN\" ] && [ -n \"$$EMAIL\" ]; then
               echo \"[orchestrator] Detected Pangolin platform (DOMAIN and EMAIL are set)\"
               COMPONENTS=\"pangolin,middleware-manager\"

--- a/orchestrator/build-compose.sh
+++ b/orchestrator/build-compose.sh
@@ -186,6 +186,8 @@ detect_base_platform() {
     echo "openclaw"
   elif has_component "hermes-agent"; then
     echo "hermes-agent"
+  elif has_component "opencomputer"; then
+    echo "opencomputer"
   elif has_component "agentgateway"; then
     echo "agentgateway"
   elif has_component "openai-chatkit" && (has_component "pangolin" || has_component "middleware-manager"); then
@@ -205,6 +207,8 @@ detect_base_platform() {
       echo "openclaw"
     elif [[ -n "${HERMES_DOMAIN:-}" && -n "${HERMES_AUTH_PASSWORD_HASH:-}" ]]; then
       echo "hermes-agent"
+    elif [[ -n "${OC_DOMAIN:-}" && -n "${OC_AUTH_PASSWORD_HASH:-}" ]]; then
+      echo "opencomputer"
     elif [[ -n "${OPENAI_API_KEY:-}" && -n "${WORKFLOW_ID:-}" && -n "${ADMIN_USERNAME:-}" && -n "${ADMIN_PASSWORD:-}" ]]; then
       echo "agentgateway"
     elif [[ -n "${OPENAI_API_KEY:-}" && -n "${WORKFLOW_ID:-}" && -z "${ADMIN_USERNAME:-}" ]]; then
@@ -350,6 +354,9 @@ EOF
   elif [[ "$BASE_PLATFORM" == "hermes-agent" ]]; then
     # Hermes Agent platform (Traefik proxy to host dashboard with basic-auth)
     sed -n '1,9999p' "$ROOT_DIR/components/hermes-agent/compose.yaml"
+  elif [[ "$BASE_PLATFORM" == "opencomputer" ]]; then
+    # OpenComputer platform (Traefik proxy to host agent dashboard with basic-auth)
+    sed -n '1,9999p' "$ROOT_DIR/components/opencomputer/compose.yaml"
   fi
 
   # Optional components (platform-agnostic)
@@ -689,6 +696,10 @@ export HERMES_SUBDOMAIN="\${HERMES_SUBDOMAIN:-hermes}"
 export HERMES_DOMAIN="\${HERMES_DOMAIN:-}"
 export HERMES_AUTH_USER="\${HERMES_AUTH_USER:-admin}"
 export HERMES_AUTH_PASSWORD_HASH="\${HERMES_AUTH_PASSWORD_HASH:-}"
+export OC_SUBDOMAIN="\${OC_SUBDOMAIN:-computer}"
+export OC_DOMAIN="\${OC_DOMAIN:-}"
+export OC_AUTH_USER="\${OC_AUTH_USER:-admin}"
+export OC_AUTH_PASSWORD_HASH="\${OC_AUTH_PASSWORD_HASH:-}"
 
 log() { printf "%s\n" "\$*"; }
 run_component_hooks() {
@@ -768,6 +779,10 @@ export HERMES_SUBDOMAIN="\${HERMES_SUBDOMAIN:-hermes}"
 export HERMES_DOMAIN="\${HERMES_DOMAIN:-}"
 export HERMES_AUTH_USER="\${HERMES_AUTH_USER:-admin}"
 export HERMES_AUTH_PASSWORD_HASH="\${HERMES_AUTH_PASSWORD_HASH:-}"
+export OC_SUBDOMAIN="\${OC_SUBDOMAIN:-computer}"
+export OC_DOMAIN="\${OC_DOMAIN:-}"
+export OC_AUTH_USER="\${OC_AUTH_USER:-admin}"
+export OC_AUTH_PASSWORD_HASH="\${OC_AUTH_PASSWORD_HASH:-}"
 
 log() { printf "%s\n" "\$*"; }
 run_component_hooks() {


### PR DESCRIPTION
Adds the on-VPS orchestrator support for the new **OpenComputer** package. Companion to
`manidae-cloud` `feature/opencomputer-package` — **merge both together**: the manidae-cloud
cloud deploy clones this repo at `MANIDAE_BRANCH` and runs the orchestrator, so without these
changes an OpenComputer host comes up with no Traefik/reverse-proxy layer.

## What this does
OpenComputer's agent runs as a QEMU/KVM VM whose UI (dashboard + embedded desktop) is served
inside the guest and forwarded to `127.0.0.1:9800` on the host. This repo provides the
Traefik component that exposes that loopback UI publicly with TLS + basic-auth.

## Changes
- **`components/opencomputer/`** — new component (mirrors `hermes-agent`):
  - `compose.yaml` — Traefik (host network) reverse proxy.
  - `config-setup.sh` — generates the Traefik rule: **one router**, `basicAuth` on **all
    paths**, `Host({OC_SUBDOMAIN}.{OC_DOMAIN}) → http://127.0.0.1:9800`, Let's Encrypt cert.
    (Simpler than Hermes — no `/api` split or Origin-rewrite: verified in Chromium + Firefox
    that the browser sends cached basic-auth on the `/ws/events` and `/desktop` WebSocket
    upgrades, so a single router works.)
  - `component.json` — declares `OC_SUBDOMAIN` / `OC_DOMAIN` / `OC_AUTH_USER` /
    `OC_AUTH_PASSWORD_HASH` / `EMAIL`.
- **`orchestrator/build-compose.sh`** — detect `opencomputer` as a base platform (explicit
  `COMPONENTS=opencomputer` + auto-derive from `OC_DOMAIN`/`OC_AUTH_PASSWORD_HASH`), emit the
  component's compose, and default the `OC_*` env vars.
- **`docker-compose-setup.yml`** — the Komodo setup entrypoint has its **own** platform
  detection (separate from `build-compose.sh`); it now recognises `opencomputer` and passes
  the `OC_*` env into the orchestrator container. *(Without this the orchestrator errored
  "No platform detected" and never wrote the main compose — the root cause of the first
  failed cloud deploy.)*

## Testing
Exercised end-to-end via the real Komodo pipeline on a DigitalOcean host: the orchestrator
detects `opencomputer`, writes `compose.yaml`, generates the Traefik rule, and the agent
dashboard is reachable over HTTPS with per-agent basic-auth. Multi-agent hosts add one
hot-reloaded rule per extra agent (written by the manidae-cloud reconciler into this
component's rules dir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)